### PR TITLE
Use Figaro gem for managing environment vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 /config/_github.yml
 /app/assets/stylesheets/users.css.scss*
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ group :development do
 	gem 'binding_of_caller'
 end
 
+gem 'figaro'
+
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
     execjs (2.2.1)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    figaro (0.7.0)
+      bundler (~> 1.0)
+      rails (>= 3, < 5)
     hashie (3.3.1)
     hike (1.2.3)
     hirb (0.7.2)
@@ -154,6 +157,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  figaro
   hirb
   jbuilder (~> 2.0)
   jquery-rails

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,8 +1,11 @@
 # config/initializers/omniauth.rb
 Rails.application.config.middleware.use OmniAuth::Builder do
-	GITHUB_CONFIG = YAML.load_file("#{::Rails.root}/config/_github.yml")[::Rails.env]
+	# GITHUB_CONFIG = YAML.load_file("#{::Rails.root}/config/_github.yml")[::Rails.env]
 
-  # If you choose to use ENV variables, you can use the following format:
-  # provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "user:email,user:follow"
-  provider :github, GITHUB_CONFIG['app_id'], GITHUB_CONFIG['secret'], scope: "user:email,user:follow"
+  # If you choose to use ENV variables with "config/application.yml" file with figaro,
+  # you can use the following format:
+  provider :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: "user:email,user:follow"
+
+  # If using "config/_github.yml", use the following declaration with the the YAML load file call above:
+  # provider :github, GITHUB_CONFIG['app_id'], GITHUB_CONFIG['secret'], scope: "user:email,user:follow"
 end


### PR DESCRIPTION
Closes #15

**Gemfile**: added figaro gem
**config/application.yml**: added after running 'rails generate figaro:install', which auto-adds this file to .gitignore; includes github ID and Secret
**config/initializers/omniauth.rb**: using ENV hash instead of YAML load file call, this will allow ease of better setup for Heroku deployment with dev/test/prod client IDs and Secrets
#### References:
- Figaro Install run issue & solution: http://stackoverflow.com/questions/21274678/rails-could-not-find-generator-figaroinstall
- Figaro gem: https://github.com/laserlemon/figaro
