### PR TITLE
fixed json path that wasn't working

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,8 @@
 class QuestionsController < ApplicationController
   before_action :set_question, only: [:show, :edit, :update, :destroy]
+  before_action :set_question_set
   before_action :require_login
+
   
   # GET /questions
   # GET /questions.json
@@ -57,6 +59,10 @@ class QuestionsController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_question
       @question = Question.find(params[:id])
+    end
+
+    def set_question_set
+      @question_set = QuestionSet.find(params[:question_set_id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/views/questions/index.json.jbuilder
+++ b/app/views/questions/index.json.jbuilder
@@ -1,4 +1,4 @@
 json.array!(@questions) do |question|
-  json.extract! question, :id :type, :content
-  json.url question_url(question, format: :json)
+  json.extract! question, :id, :type, :content
+  json.url question_set_question_url(@question_set, question, format: :json)
 end


### PR DESCRIPTION
set_question_set method in questions controller, and fixed path in index.json.builder

Because of something else, I realized that /question_sets/1/questions.json was throwing an error.  Spoke with Christine.  Did a quick fix in it's own branch.  Here it is.
